### PR TITLE
Governance asserts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3883,20 +3883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-timelock-proposal-loader-client"
-version = "0.1.0"
-dependencies = [
- "base64 0.13.0",
- "bincode",
- "solana-client",
- "solana-program",
- "solana-sdk",
- "solana-transaction-status",
- "spl-timelock",
- "spl-token 3.1.0",
-]
-
-[[package]]
 name = "spl-token"
 version = "3.1.0"
 dependencies = [

--- a/timelock/program/.gitignore
+++ b/timelock/program/.gitignore
@@ -1,0 +1,1 @@
+test-ledger

--- a/timelock/program/src/error.rs
+++ b/timelock/program/src/error.rs
@@ -115,6 +115,10 @@ pub enum TimelockError {
     #[error("Provided wrong mint type for a token holding account on timelock set")]
     MintsShouldMatch,
 
+    /// Provided source mint decimals don't match voting mint decimals
+    #[error("Provided source mint decimals don't match voting mint decimals")]
+    MintsDecimalsShouldMatch,
+
     /// Waiting period must be greater than or equal to minimum waiting period
     #[error("Waiting period must be greater than or equal to minimum waiting period")]
     MustBeAboveMinimumWaitingPeriod,

--- a/timelock/program/src/error.rs
+++ b/timelock/program/src/error.rs
@@ -39,6 +39,14 @@ pub enum TimelockError {
     #[error("Timelock Transaction not found on the Timelock Set")]
     TimelockTransactionNotFoundError,
 
+    /// Mint authority can't be deserialized
+    #[error("Mint authority can't be deserialized")]
+    MintAuthorityUnpackError,
+
+    /// Wrong mint authority was provided for mint
+    #[error("Wrong mint authority was provided for mint")]
+    InvalidMintAuthorityError,
+
     /// The wrong signatory mint was given for this timelock set
     #[error("The wrong signatory mint was given for this timelock set")]
     InvalidSignatoryMintError,

--- a/timelock/program/src/error.rs
+++ b/timelock/program/src/error.rs
@@ -47,6 +47,10 @@ pub enum TimelockError {
     #[error("Wrong mint authority was provided for mint")]
     InvalidMintAuthorityError,
 
+    /// Invalid mint owner program"
+    #[error("Invalid mint owner program")]
+    InvalidMintOwnerProgramError,
+
     /// Invalid account owner
     #[error("Invalid account owner")]
     InvalidAccountOwnerError,

--- a/timelock/program/src/error.rs
+++ b/timelock/program/src/error.rs
@@ -47,6 +47,10 @@ pub enum TimelockError {
     #[error("Wrong mint authority was provided for mint")]
     InvalidMintAuthorityError,
 
+    /// Invalid account owner
+    #[error("Invalid account owner")]
+    InvalidAccountOwnerError,
+
     /// The wrong signatory mint was given for this timelock set
     #[error("The wrong signatory mint was given for this timelock set")]
     InvalidSignatoryMintError,

--- a/timelock/program/src/instruction.rs
+++ b/timelock/program/src/instruction.rs
@@ -11,20 +11,6 @@ use crate::{
     },
 };
 
-/// Used for telling caller what type of format you want back
-#[derive(Clone, PartialEq)]
-pub enum Format {
-    /// JSON format
-    JSON,
-    /// MsgPack format
-    MsgPack,
-}
-impl Default for Format {
-    fn default() -> Self {
-        Format::JSON
-    }
-}
-
 /// Instructions supported by the Timelock program.
 #[derive(Clone)]
 #[allow(clippy::large_enum_variant)]

--- a/timelock/program/src/instruction.rs
+++ b/timelock/program/src/instruction.rs
@@ -27,6 +27,7 @@ impl Default for Format {
 
 /// Instructions supported by the Timelock program.
 #[derive(Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum TimelockInstruction {
     /// Initializes a new empty Timelocked set of Instructions that will be executed at various slots in the future in draft mode.
     /// Grants Admin token to caller.
@@ -308,15 +309,11 @@ impl TimelockInstruction {
         Ok(match tag {
             1 => {
                 let (input_desc_link, input_name) = rest.split_at(DESC_SIZE);
-                let mut desc_link: [u8; DESC_SIZE] = [0; DESC_SIZE];
-                let mut name: [u8; NAME_SIZE] = [0; NAME_SIZE];
-                for n in 0..(DESC_SIZE - 1) {
-                    desc_link[n] = input_desc_link[n];
-                }
+                let mut desc_link = [0u8; DESC_SIZE];
+                let mut name = [0u8; NAME_SIZE];
 
-                for n in 0..(NAME_SIZE - 1) {
-                    name[n] = input_name[n];
-                }
+                desc_link.clone_from_slice(&input_desc_link);
+                name.clone_from_slice(&input_name[..(NAME_SIZE - 1)]);
                 Self::InitTimelockSet { desc_link, name }
             }
             2 => Self::AddSigner,
@@ -357,10 +354,8 @@ impl TimelockInstruction {
                 let (voting_entry_rule, rest) = Self::unpack_u8(rest)?;
                 let (minimum_slot_waiting_period, rest) = Self::unpack_u64(rest)?;
                 let (time_limit, rest) = Self::unpack_u64(rest)?;
-                let mut name: [u8; CONFIG_NAME_LENGTH] = [0; CONFIG_NAME_LENGTH];
-                for n in 0..(CONFIG_NAME_LENGTH - 1) {
-                    name[n] = rest[n];
-                }
+                let mut name = [0u8; CONFIG_NAME_LENGTH];
+                name.clone_from_slice(&rest[..(CONFIG_NAME_LENGTH - 1)]);
                 Self::InitTimelockConfig {
                     consensus_algorithm,
                     execution_type,
@@ -431,10 +426,8 @@ impl TimelockInstruction {
             }
 
             let (input_instruction, rest) = input.split_at(INSTRUCTION_LIMIT);
-            let mut instruction: [u8; INSTRUCTION_LIMIT] = [0; INSTRUCTION_LIMIT];
-            for n in 0..(INSTRUCTION_LIMIT - 1) {
-                instruction[n] = input_instruction[n];
-            }
+            let mut instruction = [0u8; INSTRUCTION_LIMIT];
+            instruction.clone_from_slice(&input_instruction);
             Ok((instruction, rest))
         } else {
             Err(TimelockError::InstructionUnpackError.into())

--- a/timelock/program/src/instruction.rs
+++ b/timelock/program/src/instruction.rs
@@ -312,8 +312,8 @@ impl TimelockInstruction {
                 let mut desc_link = [0u8; DESC_SIZE];
                 let mut name = [0u8; NAME_SIZE];
 
-                desc_link.clone_from_slice(&input_desc_link);
-                name.clone_from_slice(&input_name[..(NAME_SIZE - 1)]);
+                desc_link[..(DESC_SIZE - 1)].clone_from_slice(&input_desc_link[..(DESC_SIZE - 1)]);
+                name[..(NAME_SIZE - 1)].clone_from_slice(&input_name[..(NAME_SIZE - 1)]);
                 Self::InitTimelockSet { desc_link, name }
             }
             2 => Self::AddSigner,
@@ -354,8 +354,10 @@ impl TimelockInstruction {
                 let (voting_entry_rule, rest) = Self::unpack_u8(rest)?;
                 let (minimum_slot_waiting_period, rest) = Self::unpack_u64(rest)?;
                 let (time_limit, rest) = Self::unpack_u64(rest)?;
+
                 let mut name = [0u8; CONFIG_NAME_LENGTH];
-                name.clone_from_slice(&rest[..(CONFIG_NAME_LENGTH - 1)]);
+                name[..(CONFIG_NAME_LENGTH - 1)]
+                    .clone_from_slice(&rest[..(CONFIG_NAME_LENGTH - 1)]);
                 Self::InitTimelockConfig {
                     consensus_algorithm,
                     execution_type,
@@ -427,7 +429,8 @@ impl TimelockInstruction {
 
             let (input_instruction, rest) = input.split_at(INSTRUCTION_LIMIT);
             let mut instruction = [0u8; INSTRUCTION_LIMIT];
-            instruction.clone_from_slice(&input_instruction);
+            instruction[..(INSTRUCTION_LIMIT - 1)]
+                .clone_from_slice(&input_instruction[..(INSTRUCTION_LIMIT - 1)]);
             Ok((instruction, rest))
         } else {
             Err(TimelockError::InstructionUnpackError.into())

--- a/timelock/program/src/instruction.rs
+++ b/timelock/program/src/instruction.rs
@@ -36,8 +36,8 @@ pub enum TimelockInstruction {
     ///   15. `[writable]` Initialized source holding account
     ///   16. `[]` Source mint
     ///   17. `[]` Timelock minting authority (pda with seed of timelock set key)
-    ///   19. '[]` Token program id
-    ///   20. `[]` Rent sysvar
+    ///   18. '[]` Token program id
+    ///   19. `[]` Rent sysvar
     InitTimelockSet {
         /// Link to gist explaining proposal
         desc_link: [u8; DESC_SIZE],

--- a/timelock/program/src/processor/process_add_custom_single_signer_transaction.rs
+++ b/timelock/program/src/processor/process_add_custom_single_signer_transaction.rs
@@ -89,12 +89,12 @@ pub fn process_add_custom_single_signer_transaction(
     };
 
     TimelockState::pack(
-        timelock_state.clone(),
+        timelock_state,
         &mut timelock_state_account_info.data.borrow_mut(),
     )?;
 
     CustomSingleSignerTimelockTransaction::pack(
-        timelock_txn.clone(),
+        timelock_txn,
         &mut timelock_txn_account_info.data.borrow_mut(),
     )?;
 

--- a/timelock/program/src/processor/process_add_signer.rs
+++ b/timelock/program/src/processor/process_add_signer.rs
@@ -72,7 +72,7 @@ pub fn process_add_signer(program_id: &Pubkey, accounts: &[AccountInfo]) -> Prog
         };
 
     TimelockState::pack(
-        timelock_state.clone(),
+        timelock_state,
         &mut timelock_state_account_info.data.borrow_mut(),
     )?;
     Ok(())

--- a/timelock/program/src/processor/process_add_signer.rs
+++ b/timelock/program/src/processor/process_add_signer.rs
@@ -61,7 +61,7 @@ pub fn process_add_signer(program_id: &Pubkey, accounts: &[AccountInfo]) -> Prog
         destination: new_signatory_account_info.clone(),
         amount: 1,
         authority: timelock_program_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_account_info.clone(),
     })?;
 

--- a/timelock/program/src/processor/process_delete_timelock_set.rs
+++ b/timelock/program/src/processor/process_delete_timelock_set.rs
@@ -46,7 +46,7 @@ pub fn process_delete_timelock_set(program_id: &Pubkey, accounts: &[AccountInfo]
     )?;
     timelock_state.status = TimelockStateStatus::Deleted;
     TimelockState::pack(
-        timelock_state.clone(),
+        timelock_state,
         &mut timelock_state_account_info.data.borrow_mut(),
     )?;
     Ok(())

--- a/timelock/program/src/processor/process_deposit_source_tokens.rs
+++ b/timelock/program/src/processor/process_deposit_source_tokens.rs
@@ -97,7 +97,7 @@ pub fn process_deposit_source_tokens(
         };
     }
     GovernanceVotingRecord::pack(
-        voting_record.clone(),
+        voting_record,
         &mut voting_record_account_info.data.borrow_mut(),
     )?;
     Ok(())

--- a/timelock/program/src/processor/process_deposit_source_tokens.rs
+++ b/timelock/program/src/processor/process_deposit_source_tokens.rs
@@ -52,7 +52,7 @@ pub fn process_deposit_source_tokens(
         destination: voting_account_info.clone(),
         amount: voting_token_amount,
         authority: timelock_program_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_account_info.clone(),
     })?;
 
@@ -61,7 +61,7 @@ pub fn process_deposit_source_tokens(
         destination: source_holding_account_info.clone(),
         amount: voting_token_amount,
         authority: transfer_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_account_info.clone(),
     })?;
 

--- a/timelock/program/src/processor/process_execute.rs
+++ b/timelock/program/src/processor/process_execute.rs
@@ -129,7 +129,7 @@ pub fn process_execute(
     transaction.executed = 1;
 
     CustomSingleSignerTimelockTransaction::pack(
-        transaction.clone(),
+        transaction,
         &mut transaction_account_info.data.borrow_mut(),
     )?;
 

--- a/timelock/program/src/processor/process_init_timelock_config.rs
+++ b/timelock/program/src/processor/process_init_timelock_config.rs
@@ -13,6 +13,7 @@ use solana_program::{
 };
 
 /// Init timelock config
+#[allow(clippy::too_many_arguments)]
 pub fn process_init_timelock_config(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/timelock/program/src/processor/process_init_timelock_set.rs
+++ b/timelock/program/src/processor/process_init_timelock_set.rs
@@ -1,6 +1,6 @@
 //! Program state processor
 
-use crate::utils::{assert_account_owner, assert_mint_authority};
+use crate::utils::{assert_account_owner, assert_mint_authority, assert_mint_owner_program};
 use crate::{
     error::TimelockError,
     state::{
@@ -98,12 +98,19 @@ pub fn process_init_timelock_set(
     assert_rent_exempt(rent, voting_validation_account_info)?;
 
     // Cheap computational and stack-wise calls for initialization checks, no deserialization required
+    assert_mint_initialized(signatory_mint_account_info)?;
     assert_mint_initialized(admin_mint_account_info)?;
     assert_mint_initialized(voting_mint_account_info)?;
     assert_mint_initialized(yes_voting_mint_account_info)?;
     assert_mint_initialized(no_voting_mint_account_info)?;
-    assert_mint_initialized(signatory_mint_account_info)?;
     assert_mint_initialized(source_mint_account_info)?;
+
+    assert_mint_owner_program(signatory_mint_account_info, token_program_info.key)?;
+    assert_mint_owner_program(admin_mint_account_info, token_program_info.key)?;
+    assert_mint_owner_program(voting_mint_account_info, token_program_info.key)?;
+    assert_mint_owner_program(yes_voting_mint_account_info, token_program_info.key)?;
+    assert_mint_owner_program(no_voting_mint_account_info, token_program_info.key)?;
+    assert_mint_owner_program(source_mint_account_info, token_program_info.key)?;
 
     let source_holding_mint: Pubkey = get_mint_from_token_account(source_holding_account_info)?;
 
@@ -149,11 +156,11 @@ pub fn process_init_timelock_set(
     assert_mint_decimals(yes_voting_mint_account_info, source_mint_decimals)?;
     assert_mint_decimals(no_voting_mint_account_info, source_mint_decimals)?;
 
-    assert_mint_authority(admin_mint_account_info, timelock_program_authority_info.key)?;
     assert_mint_authority(
         signatory_mint_account_info,
         timelock_program_authority_info.key,
     )?;
+    assert_mint_authority(admin_mint_account_info, timelock_program_authority_info.key)?;
     assert_mint_authority(
         voting_mint_account_info,
         timelock_program_authority_info.key,

--- a/timelock/program/src/processor/process_init_timelock_set.rs
+++ b/timelock/program/src/processor/process_init_timelock_set.rs
@@ -1,6 +1,6 @@
 //! Program state processor
 
-use crate::utils::assert_mint_authority;
+use crate::utils::{assert_account_owner, assert_mint_authority};
 use crate::{
     error::TimelockError,
     state::{
@@ -11,7 +11,7 @@ use crate::{
     },
     utils::{
         assert_account_mint, assert_initialized, assert_mint_decimals, assert_mint_initialized,
-        assert_rent_exempt, assert_uninitialized, get_mint_decimals, get_mint_from_account,
+        assert_rent_exempt, assert_uninitialized, get_mint_decimals, get_mint_from_token_account,
         spl_token_mint_to, TokenMintToParams,
     },
 };
@@ -105,7 +105,7 @@ pub fn process_init_timelock_set(
     assert_mint_initialized(signatory_mint_account_info)?;
     assert_mint_initialized(source_mint_account_info)?;
 
-    let source_holding_mint: Pubkey = get_mint_from_account(source_holding_account_info)?;
+    let source_holding_mint: Pubkey = get_mint_from_token_account(source_holding_account_info)?;
 
     assert_account_mint(destination_sig_account_info, signatory_mint_account_info)?;
     assert_account_mint(destination_admin_account_info, admin_mint_account_info)?;
@@ -118,6 +118,31 @@ pub fn process_init_timelock_set(
     assert_account_mint(yes_voting_dump_account_info, yes_voting_mint_account_info)?;
     assert_account_mint(no_voting_dump_account_info, no_voting_mint_account_info)?;
     assert_account_mint(source_holding_account_info, source_mint_account_info)?;
+
+    assert_account_owner(
+        signatory_validation_account_info,
+        timelock_program_authority_info.key,
+    )?;
+    assert_account_owner(
+        admin_validation_account_info,
+        timelock_program_authority_info.key,
+    )?;
+    assert_account_owner(
+        voting_validation_account_info,
+        timelock_program_authority_info.key,
+    )?;
+    assert_account_owner(
+        yes_voting_dump_account_info,
+        timelock_program_authority_info.key,
+    )?;
+    assert_account_owner(
+        no_voting_dump_account_info,
+        timelock_program_authority_info.key,
+    )?;
+    assert_account_owner(
+        source_holding_account_info,
+        timelock_program_authority_info.key,
+    )?;
 
     let source_mint_decimals = get_mint_decimals(source_mint_account_info)?;
     assert_mint_decimals(voting_mint_account_info, source_mint_decimals)?;

--- a/timelock/program/src/processor/process_init_timelock_set.rs
+++ b/timelock/program/src/processor/process_init_timelock_set.rs
@@ -154,7 +154,7 @@ pub fn process_init_timelock_set(
         destination: destination_admin_account_info.clone(),
         amount: 1,
         authority: timelock_program_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_info.clone(),
     })?;
 
@@ -163,7 +163,7 @@ pub fn process_init_timelock_set(
         destination: destination_sig_account_info.clone(),
         amount: 1,
         authority: timelock_program_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_info.clone(),
     })?;
     Ok(())

--- a/timelock/program/src/processor/process_init_timelock_set.rs
+++ b/timelock/program/src/processor/process_init_timelock_set.rs
@@ -1,5 +1,6 @@
 //! Program state processor
 
+use crate::utils::assert_mint_authority;
 use crate::{
     error::TimelockError,
     state::{
@@ -9,9 +10,9 @@ use crate::{
         timelock_state::{DESC_SIZE, NAME_SIZE},
     },
     utils::{
-        assert_cheap_mint_initialized, assert_initialized, assert_mint_decimals,
-        assert_mint_matching, assert_rent_exempt, assert_uninitialized, get_mint_from_account,
-        pull_mint_decimals, spl_token_mint_to, TokenMintToParams,
+        assert_initialized, assert_mint_decimals, assert_mint_initialized, assert_mint_matching,
+        assert_rent_exempt, assert_uninitialized, get_mint_decimals, get_mint_from_account,
+        spl_token_mint_to, TokenMintToParams,
     },
 };
 use solana_program::{
@@ -31,31 +32,31 @@ pub fn process_init_timelock_set(
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
-    let timelock_state_account_info = next_account_info(account_info_iter)?;
-    let timelock_set_account_info = next_account_info(account_info_iter)?;
-    let timelock_config_account_info = next_account_info(account_info_iter)?;
-    let signatory_mint_account_info = next_account_info(account_info_iter)?;
-    let admin_mint_account_info = next_account_info(account_info_iter)?;
-    let voting_mint_account_info = next_account_info(account_info_iter)?;
-    let yes_voting_mint_account_info = next_account_info(account_info_iter)?;
-    let no_voting_mint_account_info = next_account_info(account_info_iter)?;
-    let signatory_validation_account_info = next_account_info(account_info_iter)?;
-    let admin_validation_account_info = next_account_info(account_info_iter)?;
-    let voting_validation_account_info = next_account_info(account_info_iter)?;
-    let destination_admin_account_info = next_account_info(account_info_iter)?;
-    let destination_sig_account_info = next_account_info(account_info_iter)?;
-    let yes_voting_dump_account_info = next_account_info(account_info_iter)?;
-    let no_voting_dump_account_info = next_account_info(account_info_iter)?;
-    let source_holding_account_info = next_account_info(account_info_iter)?;
-    let source_mint_account_info = next_account_info(account_info_iter)?;
-    let timelock_program_authority_info = next_account_info(account_info_iter)?;
-    let token_program_info = next_account_info(account_info_iter)?;
-    let rent_info = next_account_info(account_info_iter)?;
+    let timelock_state_account_info = next_account_info(account_info_iter)?; //0
+    let timelock_set_account_info = next_account_info(account_info_iter)?; //1
+    let timelock_config_account_info = next_account_info(account_info_iter)?; //2
+    let signatory_mint_account_info = next_account_info(account_info_iter)?; //3
+    let admin_mint_account_info = next_account_info(account_info_iter)?; //4
+    let voting_mint_account_info = next_account_info(account_info_iter)?; //5
+    let yes_voting_mint_account_info = next_account_info(account_info_iter)?; //6
+    let no_voting_mint_account_info = next_account_info(account_info_iter)?; //7
+    let signatory_validation_account_info = next_account_info(account_info_iter)?; //8
+    let admin_validation_account_info = next_account_info(account_info_iter)?; //9
+    let voting_validation_account_info = next_account_info(account_info_iter)?; //10
+    let destination_admin_account_info = next_account_info(account_info_iter)?; //11
+    let destination_sig_account_info = next_account_info(account_info_iter)?; //12
+    let yes_voting_dump_account_info = next_account_info(account_info_iter)?; //13
+    let no_voting_dump_account_info = next_account_info(account_info_iter)?; //14
+    let source_holding_account_info = next_account_info(account_info_iter)?; //15
+    let source_mint_account_info = next_account_info(account_info_iter)?; //16
+    let timelock_program_authority_info = next_account_info(account_info_iter)?; //17
+    let token_program_info = next_account_info(account_info_iter)?; //18
+    let rent_info = next_account_info(account_info_iter)?; //19
     let rent = &Rent::from_account_info(rent_info)?;
 
-    let mut timelock_config: TimelockConfig = assert_initialized(timelock_config_account_info)?;
     let mut new_timelock_state: TimelockState = assert_uninitialized(timelock_state_account_info)?;
     let mut new_timelock_set: TimelockSet = assert_uninitialized(timelock_set_account_info)?;
+    let mut timelock_config: TimelockConfig = assert_initialized(timelock_config_account_info)?;
 
     new_timelock_set.version = TIMELOCK_SET_VERSION;
     new_timelock_set.config = *timelock_config_account_info.key;
@@ -96,13 +97,13 @@ pub fn process_init_timelock_set(
     assert_rent_exempt(rent, signatory_validation_account_info)?;
     assert_rent_exempt(rent, voting_validation_account_info)?;
 
-    // Cheap computational and stack-wise calls for initialization checks, no deserialization req'd
-    assert_cheap_mint_initialized(admin_mint_account_info)?;
-    assert_cheap_mint_initialized(voting_mint_account_info)?;
-    assert_cheap_mint_initialized(yes_voting_mint_account_info)?;
-    assert_cheap_mint_initialized(no_voting_mint_account_info)?;
-    assert_cheap_mint_initialized(signatory_mint_account_info)?;
-    assert_cheap_mint_initialized(source_mint_account_info)?;
+    // Cheap computational and stack-wise calls for initialization checks, no deserialization required
+    assert_mint_initialized(admin_mint_account_info)?;
+    assert_mint_initialized(voting_mint_account_info)?;
+    assert_mint_initialized(yes_voting_mint_account_info)?;
+    assert_mint_initialized(no_voting_mint_account_info)?;
+    assert_mint_initialized(signatory_mint_account_info)?;
+    assert_mint_initialized(source_mint_account_info)?;
 
     let source_holding_mint: Pubkey = get_mint_from_account(source_holding_account_info)?;
 
@@ -118,10 +119,28 @@ pub fn process_init_timelock_set(
     assert_mint_matching(no_voting_dump_account_info, no_voting_mint_account_info)?;
     assert_mint_matching(source_holding_account_info, source_mint_account_info)?;
 
-    let source_mint_decimals = pull_mint_decimals(source_mint_account_info)?;
+    let source_mint_decimals = get_mint_decimals(source_mint_account_info)?;
     assert_mint_decimals(voting_mint_account_info, source_mint_decimals)?;
     assert_mint_decimals(yes_voting_mint_account_info, source_mint_decimals)?;
     assert_mint_decimals(no_voting_mint_account_info, source_mint_decimals)?;
+
+    assert_mint_authority(admin_mint_account_info, timelock_program_authority_info.key)?;
+    assert_mint_authority(
+        signatory_mint_account_info,
+        timelock_program_authority_info.key,
+    )?;
+    assert_mint_authority(
+        voting_mint_account_info,
+        timelock_program_authority_info.key,
+    )?;
+    assert_mint_authority(
+        yes_voting_mint_account_info,
+        timelock_program_authority_info.key,
+    )?;
+    assert_mint_authority(
+        no_voting_mint_account_info,
+        timelock_program_authority_info.key,
+    )?;
 
     if source_holding_mint != timelock_config.governance_mint
         && source_holding_mint != timelock_config.council_mint

--- a/timelock/program/src/processor/process_init_timelock_set.rs
+++ b/timelock/program/src/processor/process_init_timelock_set.rs
@@ -10,7 +10,7 @@ use crate::{
         timelock_state::{DESC_SIZE, NAME_SIZE},
     },
     utils::{
-        assert_initialized, assert_mint_decimals, assert_mint_initialized, assert_mint_matching,
+        assert_account_mint, assert_initialized, assert_mint_decimals, assert_mint_initialized,
         assert_rent_exempt, assert_uninitialized, get_mint_decimals, get_mint_from_account,
         spl_token_mint_to, TokenMintToParams,
     },
@@ -107,17 +107,17 @@ pub fn process_init_timelock_set(
 
     let source_holding_mint: Pubkey = get_mint_from_account(source_holding_account_info)?;
 
-    assert_mint_matching(destination_sig_account_info, signatory_mint_account_info)?;
-    assert_mint_matching(destination_admin_account_info, admin_mint_account_info)?;
-    assert_mint_matching(
+    assert_account_mint(destination_sig_account_info, signatory_mint_account_info)?;
+    assert_account_mint(destination_admin_account_info, admin_mint_account_info)?;
+    assert_account_mint(
         signatory_validation_account_info,
         signatory_mint_account_info,
     )?;
-    assert_mint_matching(admin_validation_account_info, admin_mint_account_info)?;
-    assert_mint_matching(voting_validation_account_info, voting_mint_account_info)?;
-    assert_mint_matching(yes_voting_dump_account_info, yes_voting_mint_account_info)?;
-    assert_mint_matching(no_voting_dump_account_info, no_voting_mint_account_info)?;
-    assert_mint_matching(source_holding_account_info, source_mint_account_info)?;
+    assert_account_mint(admin_validation_account_info, admin_mint_account_info)?;
+    assert_account_mint(voting_validation_account_info, voting_mint_account_info)?;
+    assert_account_mint(yes_voting_dump_account_info, yes_voting_mint_account_info)?;
+    assert_account_mint(no_voting_dump_account_info, no_voting_mint_account_info)?;
+    assert_account_mint(source_holding_account_info, source_mint_account_info)?;
 
     let source_mint_decimals = get_mint_decimals(source_mint_account_info)?;
     assert_mint_decimals(voting_mint_account_info, source_mint_decimals)?;

--- a/timelock/program/src/processor/process_remove_signer.rs
+++ b/timelock/program/src/processor/process_remove_signer.rs
@@ -61,7 +61,7 @@ pub fn process_remove_signer(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
         mint: signatory_mint_info.clone(),
         amount: 1,
         authority: transfer_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_account_info.clone(),
         source: remove_signatory_account_info.clone(),
     })?;

--- a/timelock/program/src/processor/process_remove_signer.rs
+++ b/timelock/program/src/processor/process_remove_signer.rs
@@ -68,7 +68,7 @@ pub fn process_remove_signer(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
     timelock_state.total_signing_tokens_minted -= 1;
 
     TimelockState::pack(
-        timelock_state.clone(),
+        timelock_state,
         &mut timelock_state_account_info.data.borrow_mut(),
     )?;
     Ok(())

--- a/timelock/program/src/processor/process_remove_transaction.rs
+++ b/timelock/program/src/processor/process_remove_transaction.rs
@@ -68,7 +68,7 @@ pub fn process_remove_transaction(program_id: &Pubkey, accounts: &[AccountInfo])
     };
 
     TimelockState::pack(
-        timelock_state.clone(),
+        timelock_state,
         &mut timelock_state_account_info.data.borrow_mut(),
     )?;
 

--- a/timelock/program/src/processor/process_sign.rs
+++ b/timelock/program/src/processor/process_sign.rs
@@ -51,7 +51,7 @@ pub fn process_sign(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramRes
         mint: signatory_mint_info.clone(),
         amount: 1,
         authority: transfer_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_account_info.clone(),
         source: signatory_account_info.clone(),
     })?;

--- a/timelock/program/src/processor/process_sign.rs
+++ b/timelock/program/src/processor/process_sign.rs
@@ -67,7 +67,7 @@ pub fn process_sign(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramRes
         timelock_state.voting_began_at = clock.slot;
 
         TimelockState::pack(
-            timelock_state.clone(),
+            timelock_state,
             &mut timelock_state_account_info.data.borrow_mut(),
         )?;
     }

--- a/timelock/program/src/processor/process_vote.rs
+++ b/timelock/program/src/processor/process_vote.rs
@@ -91,7 +91,7 @@ pub fn process_vote(
         mint: voting_mint_account_info.clone(),
         amount: yes_voting_token_amount + no_voting_token_amount,
         authority: transfer_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_account_info.clone(),
         source: voting_account_info.clone(),
     })?;
@@ -101,7 +101,7 @@ pub fn process_vote(
         destination: yes_voting_account_info.clone(),
         amount: yes_voting_token_amount,
         authority: timelock_program_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_account_info.clone(),
     })?;
 
@@ -110,7 +110,7 @@ pub fn process_vote(
         destination: no_voting_account_info.clone(),
         amount: no_voting_token_amount,
         authority: timelock_program_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_account_info.clone(),
     })?;
 

--- a/timelock/program/src/processor/process_vote.rs
+++ b/timelock/program/src/processor/process_vote.rs
@@ -6,7 +6,7 @@ use crate::{
         timelock_config::TimelockConfig, timelock_set::TimelockSet, timelock_state::TimelockState,
     },
     utils::{
-        assert_account_equiv, assert_initialized, assert_voting, pull_mint_supply, spl_token_burn,
+        assert_account_equiv, assert_initialized, assert_voting, get_mint_supply, spl_token_burn,
         spl_token_mint_to, TokenBurnParams, TokenMintToParams,
     },
 };
@@ -28,21 +28,21 @@ pub fn process_vote(
     no_voting_token_amount: u64,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
-    let voting_record_account_info = next_account_info(account_info_iter)?;
-    let timelock_state_account_info = next_account_info(account_info_iter)?;
-    let voting_account_info = next_account_info(account_info_iter)?;
-    let yes_voting_account_info = next_account_info(account_info_iter)?;
-    let no_voting_account_info = next_account_info(account_info_iter)?;
-    let voting_mint_account_info = next_account_info(account_info_iter)?;
-    let yes_voting_mint_account_info = next_account_info(account_info_iter)?;
-    let no_voting_mint_account_info = next_account_info(account_info_iter)?;
-    let source_mint_account_info = next_account_info(account_info_iter)?;
-    let timelock_set_account_info = next_account_info(account_info_iter)?;
-    let timelock_config_account_info = next_account_info(account_info_iter)?;
-    let transfer_authority_info = next_account_info(account_info_iter)?;
-    let timelock_program_authority_info = next_account_info(account_info_iter)?;
-    let token_program_account_info = next_account_info(account_info_iter)?;
-    let clock_info = next_account_info(account_info_iter)?;
+    let voting_record_account_info = next_account_info(account_info_iter)?; // 0
+    let timelock_state_account_info = next_account_info(account_info_iter)?; // 1
+    let voting_account_info = next_account_info(account_info_iter)?; //2
+    let yes_voting_account_info = next_account_info(account_info_iter)?; //3
+    let no_voting_account_info = next_account_info(account_info_iter)?; //4
+    let voting_mint_account_info = next_account_info(account_info_iter)?; //5
+    let yes_voting_mint_account_info = next_account_info(account_info_iter)?; //6
+    let no_voting_mint_account_info = next_account_info(account_info_iter)?; //7
+    let source_mint_account_info = next_account_info(account_info_iter)?; //8
+    let timelock_set_account_info = next_account_info(account_info_iter)?; //9
+    let timelock_config_account_info = next_account_info(account_info_iter)?; //10
+    let transfer_authority_info = next_account_info(account_info_iter)?; //11
+    let timelock_program_authority_info = next_account_info(account_info_iter)?; //12
+    let token_program_account_info = next_account_info(account_info_iter)?; //13
+    let clock_info = next_account_info(account_info_iter)?; //14
 
     let clock = Clock::from_account_info(clock_info)?;
     let mut timelock_state: TimelockState = assert_initialized(timelock_state_account_info)?;
@@ -65,9 +65,9 @@ pub fn process_vote(
     }
     let authority_signer_seeds = &[timelock_set_account_info.key.as_ref(), &[bump_seed]];
 
-    // We dont initialize the mints because it's too expensive on the stack size.
-    let source_mint_supply: u64 = pull_mint_supply(source_mint_account_info)?;
-    let yes_mint_supply: u64 = pull_mint_supply(yes_voting_mint_account_info)?;
+    // We don't initialize the mints because it's too expensive on the stack size.
+    let source_mint_supply: u64 = get_mint_supply(source_mint_account_info)?;
+    let yes_mint_supply: u64 = get_mint_supply(yes_voting_mint_account_info)?;
 
     let total_ever_existed = source_mint_supply;
 

--- a/timelock/program/src/processor/process_vote.rs
+++ b/timelock/program/src/processor/process_vote.rs
@@ -141,7 +141,7 @@ pub fn process_vote(
         timelock_state.voting_ended_at = clock.slot;
 
         TimelockState::pack(
-            timelock_state.clone(),
+            timelock_state,
             &mut timelock_state_account_info.data.borrow_mut(),
         )?;
     }
@@ -177,7 +177,7 @@ pub fn process_vote(
         None => return Err(TimelockError::NumericalOverflow.into()),
     };
     GovernanceVotingRecord::pack(
-        voting_record.clone(),
+        voting_record,
         &mut voting_record_account_info.data.borrow_mut(),
     )?;
 

--- a/timelock/program/src/processor/process_withdraw_voting_tokens.rs
+++ b/timelock/program/src/processor/process_withdraw_voting_tokens.rs
@@ -211,7 +211,7 @@ pub fn process_withdraw_voting_tokens(
     })?;
 
     GovernanceVotingRecord::pack(
-        voting_record.clone(),
+        voting_record,
         &mut voting_record_account_info.data.borrow_mut(),
     )?;
     Ok(())

--- a/timelock/program/src/processor/process_withdraw_voting_tokens.rs
+++ b/timelock/program/src/processor/process_withdraw_voting_tokens.rs
@@ -121,7 +121,7 @@ pub fn process_withdraw_voting_tokens(
                 mint: voting_mint_account_info.clone(),
                 amount: amount_to_burn,
                 authority: transfer_authority_info.clone(),
-                authority_signer_seeds: authority_signer_seeds,
+                authority_signer_seeds,
                 token_program: token_program_account_info.clone(),
                 source: voting_account_info.clone(),
             })?;
@@ -152,7 +152,7 @@ pub fn process_withdraw_voting_tokens(
                     mint: yes_voting_mint_account_info.clone(),
                     amount: amount_to_transfer,
                     authority: transfer_authority_info.clone(),
-                    authority_signer_seeds: authority_signer_seeds,
+                    authority_signer_seeds,
                     token_program: token_program_account_info.clone(),
                     source: yes_voting_account_info.clone(),
                 })?;
@@ -162,7 +162,7 @@ pub fn process_withdraw_voting_tokens(
                     destination: yes_voting_dump_account_info.clone(),
                     amount: amount_to_transfer,
                     authority: transfer_authority_info.clone(),
-                    authority_signer_seeds: authority_signer_seeds,
+                    authority_signer_seeds,
                     token_program: token_program_account_info.clone(),
                 })?;
             }
@@ -181,7 +181,7 @@ pub fn process_withdraw_voting_tokens(
                 mint: no_voting_mint_account_info.clone(),
                 amount: voting_fuel_tank,
                 authority: transfer_authority_info.clone(),
-                authority_signer_seeds: authority_signer_seeds,
+                authority_signer_seeds,
                 token_program: token_program_account_info.clone(),
                 source: no_voting_account_info.clone(),
             })?;
@@ -191,7 +191,7 @@ pub fn process_withdraw_voting_tokens(
                 destination: no_voting_dump_account_info.clone(),
                 amount: voting_fuel_tank,
                 authority: transfer_authority_info.clone(),
-                authority_signer_seeds: authority_signer_seeds,
+                authority_signer_seeds,
                 token_program: token_program_account_info.clone(),
             })?;
         }
@@ -206,7 +206,7 @@ pub fn process_withdraw_voting_tokens(
         destination: user_account_info.clone(),
         amount: voting_token_amount,
         authority: timelock_program_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_account_info.clone(),
     })?;
 

--- a/timelock/program/src/state/custom_single_signer_timelock_transaction.rs
+++ b/timelock/program/src/state/custom_single_signer_timelock_transaction.rs
@@ -111,7 +111,7 @@ impl Pack for CustomSingleSignerTimelockTransaction {
         if input.len() != Self::LEN {
             return Err(ProgramError::InvalidAccountData);
         }
-        Ok(Self::unpack_from_slice(input)?)
+        Self::unpack_from_slice(input)
     }
 
     fn pack(src: Self, dst: &mut [u8]) -> Result<(), ProgramError> {

--- a/timelock/program/src/state/governance_voting_record.rs
+++ b/timelock/program/src/state/governance_voting_record.rs
@@ -93,7 +93,7 @@ impl Pack for GovernanceVotingRecord {
         if input.len() != Self::LEN {
             return Err(ProgramError::InvalidAccountData);
         }
-        Ok(Self::unpack_from_slice(input)?)
+        Self::unpack_from_slice(input)
     }
 
     fn pack(src: Self, dst: &mut [u8]) -> Result<(), ProgramError> {

--- a/timelock/program/src/state/timelock_config.rs
+++ b/timelock/program/src/state/timelock_config.rs
@@ -164,21 +164,21 @@ impl Pack for TimelockConfig {
         ];
         *version = self.version.to_le_bytes();
         *consensus_algorithm = match self.consensus_algorithm {
-            ConsensusAlgorithm::Majority => 0 as u8,
-            ConsensusAlgorithm::SuperMajority => 1 as u8,
-            ConsensusAlgorithm::FullConsensus => 2 as u8,
+            ConsensusAlgorithm::Majority => 0_u8,
+            ConsensusAlgorithm::SuperMajority => 1_u8,
+            ConsensusAlgorithm::FullConsensus => 2_u8,
         }
         .to_le_bytes();
         *execution_type = match self.execution_type {
-            ExecutionType::Independent => 0 as u8,
+            ExecutionType::Independent => 0_u8,
         }
         .to_le_bytes();
         *timelock_type = match self.timelock_type {
-            TimelockType::Governance => 0 as u8,
+            TimelockType::Governance => 0_u8,
         }
         .to_le_bytes();
         *voting_entry_rule = match self.voting_entry_rule {
-            VotingEntryRule::Anytime => 0 as u8,
+            VotingEntryRule::Anytime => 0_u8,
         }
         .to_le_bytes();
         *minimum_slot_waiting_period = self.minimum_slot_waiting_period.to_le_bytes();

--- a/timelock/program/src/state/timelock_config.rs
+++ b/timelock/program/src/state/timelock_config.rs
@@ -210,7 +210,7 @@ impl Pack for TimelockConfig {
         if input.len() != Self::LEN {
             return Err(ProgramError::InvalidAccountData);
         }
-        Ok(Self::unpack_from_slice(input)?)
+        Self::unpack_from_slice(input)
     }
 
     fn pack(src: Self, dst: &mut [u8]) -> Result<(), ProgramError> {

--- a/timelock/program/src/state/timelock_set.rs
+++ b/timelock/program/src/state/timelock_set.rs
@@ -182,7 +182,7 @@ impl Pack for TimelockSet {
         if input.len() != Self::LEN {
             return Err(ProgramError::InvalidAccountData);
         }
-        Ok(Self::unpack_from_slice(input)?)
+        Self::unpack_from_slice(input)
     }
 
     fn pack(src: Self, dst: &mut [u8]) -> Result<(), ProgramError> {

--- a/timelock/program/src/state/timelock_state.rs
+++ b/timelock/program/src/state/timelock_state.rs
@@ -245,7 +245,7 @@ impl Pack for TimelockState {
         if input.len() != Self::LEN {
             return Err(ProgramError::InvalidAccountData);
         }
-        Ok(Self::unpack_from_slice(input)?)
+        Self::unpack_from_slice(input)
     }
 
     fn pack(src: Self, dst: &mut [u8]) -> Result<(), ProgramError> {

--- a/timelock/program/src/state/timelock_state.rs
+++ b/timelock/program/src/state/timelock_state.rs
@@ -200,12 +200,12 @@ impl Pack for TimelockState {
         timelock_set.copy_from_slice(self.timelock_set.as_ref());
 
         *timelock_state_status = match self.status {
-            TimelockStateStatus::Draft => 0 as u8,
-            TimelockStateStatus::Voting => 1 as u8,
-            TimelockStateStatus::Executing => 2 as u8,
-            TimelockStateStatus::Completed => 3 as u8,
-            TimelockStateStatus::Deleted => 4 as u8,
-            TimelockStateStatus::Defeated => 5 as u8,
+            TimelockStateStatus::Draft => 0_u8,
+            TimelockStateStatus::Voting => 1_u8,
+            TimelockStateStatus::Executing => 2_u8,
+            TimelockStateStatus::Completed => 3_u8,
+            TimelockStateStatus::Deleted => 4_u8,
+            TimelockStateStatus::Defeated => 5_u8,
         }
         .to_le_bytes();
         *total_signing_tokens_minted = self.total_signing_tokens_minted.to_le_bytes();

--- a/timelock/program/src/utils.rs
+++ b/timelock/program/src/utils.rs
@@ -569,7 +569,7 @@ mod test {
         let owner = Pubkey::new_unique();
 
         let account = TokenAccount {
-            owner: owner,
+            owner,
             ..Default::default()
         };
 

--- a/timelock/program/src/utils.rs
+++ b/timelock/program/src/utils.rs
@@ -60,7 +60,7 @@ pub fn assert_is_permissioned<'a>(
         destination: perm_validation_account_info.clone(),
         amount: 1,
         authority: transfer_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_info.clone(),
     })?;
     // Now give it back
@@ -69,7 +69,7 @@ pub fn assert_is_permissioned<'a>(
         destination: perm_account_info.clone(),
         amount: 1,
         authority: timelock_authority_info.clone(),
-        authority_signer_seeds: authority_signer_seeds,
+        authority_signer_seeds,
         token_program: token_program_info.clone(),
     })?;
     Ok(())

--- a/timelock/program/src/utils.rs
+++ b/timelock/program/src/utils.rs
@@ -2,13 +2,14 @@ use crate::{
     error::TimelockError,
     state::{enums::TimelockStateStatus, timelock_set::TimelockSet, timelock_state::TimelockState},
 };
-use arrayref::array_ref;
+use arrayref::{array_ref, array_refs};
 use solana_program::{
     account_info::AccountInfo,
     entrypoint::ProgramResult,
     instruction::Instruction,
     program::invoke_signed,
     program_error::ProgramError,
+    program_option::COption,
     program_pack::{IsInitialized, Pack},
     pubkey::Pubkey,
     system_instruction::create_account,
@@ -163,7 +164,7 @@ pub fn assert_account_equiv(acct: &AccountInfo, key: &Pubkey) -> ProgramResult {
     Ok(())
 }
 
-/// Cheaper Assertion the account has a matching mint - if you dont plan to use Mint for anything else
+/// Cheaper Assertion the account has a matching mint - if you don't plan to use Mint for anything else
 pub fn assert_mint_matching(acct: &AccountInfo, mint: &AccountInfo) -> ProgramResult {
     let mint_key: Pubkey = get_mint_from_account(acct)?;
     if &mint_key != mint.key {
@@ -175,10 +176,18 @@ pub fn assert_mint_matching(acct: &AccountInfo, mint: &AccountInfo) -> ProgramRe
 
 /// Cheaper Assertion the account has a matching mint decimals - if you don't plan to use Mint for anything else
 pub fn assert_mint_decimals(mint: &AccountInfo, mint_decimals: u8) -> ProgramResult {
-    if pull_mint_decimals(mint).unwrap() != mint_decimals {
+    if get_mint_decimals(mint).unwrap() != mint_decimals {
         return Err(TimelockError::MintsDecimalsShouldMatch.into());
     }
 
+    Ok(())
+}
+
+/// Cheaper Assertion the account has a matching mint_authority- if you don't plan to use Mint for anything else
+pub fn assert_mint_authority(mint: &AccountInfo, mint_authority: &Pubkey) -> ProgramResult {
+    if get_mint_authority(mint).unwrap() != *mint_authority {
+        return Err(TimelockError::InvalidMintAuthorityError.into());
+    }
     Ok(())
 }
 
@@ -202,8 +211,8 @@ pub fn assert_uninitialized<T: Pack + IsInitialized>(
     }
 }
 
-/// cheap assertion of mint serialization
-pub fn assert_cheap_mint_initialized(account_info: &AccountInfo) -> Result<(), ProgramError> {
+/// cheap assertion of mint is_initialized without unpacking whole object
+pub fn assert_mint_initialized(account_info: &AccountInfo) -> Result<(), ProgramError> {
     // In token program, 36, 8, 1, 1 is the layout, where the last 1 is initialized bit.
     // Not my favorite hack, but necessary to avoid stack size limitations caused by serializing entire Mint
     // to get at initialization check
@@ -214,8 +223,8 @@ pub fn assert_cheap_mint_initialized(account_info: &AccountInfo) -> Result<(), P
     Ok(())
 }
 
-/// cheap method to just pull supply off a mint
-pub fn pull_mint_supply(account_info: &AccountInfo) -> Result<u64, ProgramError> {
+/// cheap method to just get supply off a mint without unpacking whole object
+pub fn get_mint_supply(account_info: &AccountInfo) -> Result<u64, ProgramError> {
     // In token program, 36, 8, 1, 1 is the layout, where the first 8 is supply u64.
     // so we start at 36.
     let data = account_info.try_borrow_data().unwrap();
@@ -224,8 +233,23 @@ pub fn pull_mint_supply(account_info: &AccountInfo) -> Result<u64, ProgramError>
     Ok(u64::from_le_bytes(*bytes))
 }
 
-/// cheap method to just pull decimals off a mint
-pub fn pull_mint_decimals(account_info: &AccountInfo) -> Result<u8, ProgramError> {
+/// cheap method to just get supply off a mint without unpacking whole object
+pub fn get_mint_authority(account_info: &AccountInfo) -> Result<Pubkey, ProgramError> {
+    // In token program, 36, 8, 1, 1 is the layout, where the first 36 is mint_authority
+    // so we start at 0.
+    let data = account_info.try_borrow_data().unwrap();
+    let authority_bytes = array_ref![data, 0, 36];
+
+    let authority = unpack_coption_key(&authority_bytes)?;
+
+    match authority {
+        COption::Some(pk) => Ok(pk),
+        COption::None => Err(TimelockError::MintAuthorityUnpackError.into()),
+    }
+}
+
+/// cheap method to just get decimals off a mint without unpacking whole object
+pub fn get_mint_decimals(account_info: &AccountInfo) -> Result<u8, ProgramError> {
     // In token program, 36, 8, 1, 1 is the Mint layout, where the first 1 is decimals u8.
     // so we start at 44.
     let data = account_info.try_borrow_data().unwrap();
@@ -348,6 +372,16 @@ pub fn execute(params: ExecuteParams<'_, '_>) -> ProgramResult {
     result.map_err(|_| TimelockError::ExecutionFailed.into())
 }
 
+/// Unpacks COption from a slice, taken from token program
+fn unpack_coption_key(src: &[u8; 36]) -> Result<COption<Pubkey>, ProgramError> {
+    let (tag, body) = array_refs![src, 4, 32];
+    match *tag {
+        [0, 0, 0, 0] => Ok(COption::None),
+        [1, 0, 0, 0] => Ok(COption::Some(Pubkey::new_from_array(*body))),
+        _ => Err(ProgramError::InvalidAccountData),
+    }
+}
+
 /// Create account from scratch, stolen from Wormhole, slightly altered for my purposes
 /// https://github.com/bartosz-lipinski/wormhole/blob/8478735ea7525043635524a62db2751e59d2bc38/solana/bridge/src/processor.rs#L1335
 #[inline(always)]
@@ -437,16 +471,17 @@ mod test {
 
     #[test]
     pub fn test_assert_mint_decimals() {
-        let mut data = vec![0; Mint::get_packed_len()];
+        let decimals = 5;
 
         let mint = Mint {
             mint_authority: COption::None,
             supply: 100,
-            decimals: 5,
+            decimals,
             is_initialized: true,
             freeze_authority: COption::None,
         };
 
+        let mut data = vec![0; Mint::get_packed_len()];
         Mint::pack(mint, &mut data).unwrap();
 
         let mut lamports = 0;
@@ -464,6 +499,42 @@ mod test {
             Epoch::default(),
         );
 
-        assert_eq!(assert_mint_decimals(&mint_account_info, 5), Ok(()));
+        assert_eq!(assert_mint_decimals(&mint_account_info, decimals), Ok(()));
+    }
+
+    #[test]
+    pub fn test_assert_mint_authority() {
+        let mint_authority = Pubkey::new_unique();
+
+        let mint = Mint {
+            mint_authority: COption::Some(mint_authority),
+            supply: 100,
+            decimals: 5,
+            is_initialized: true,
+            freeze_authority: COption::None,
+        };
+
+        let mut data = vec![0; Mint::get_packed_len()];
+        Mint::pack(mint, &mut data).unwrap();
+
+        let mut lamports = 0;
+
+        let program_id = Pubkey::new_unique();
+        let owner_key = Pubkey::new_unique();
+        let mint_account_info = AccountInfo::new(
+            &owner_key,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &program_id,
+            false,
+            Epoch::default(),
+        );
+
+        assert_eq!(
+            assert_mint_authority(&mint_account_info, &mint_authority),
+            Ok(())
+        );
     }
 }

--- a/timelock/program/src/utils.rs
+++ b/timelock/program/src/utils.rs
@@ -164,8 +164,8 @@ pub fn assert_account_equiv(acct: &AccountInfo, key: &Pubkey) -> ProgramResult {
     Ok(())
 }
 
-/// Cheaper Assertion the account has a matching mint - if you don't plan to use Mint for anything else
-pub fn assert_mint_matching(acct: &AccountInfo, mint: &AccountInfo) -> ProgramResult {
+/// Cheaper Assertion the account belongs to the given mint - if you don't plan to use Mint for anything else
+pub fn assert_account_mint(acct: &AccountInfo, mint: &AccountInfo) -> ProgramResult {
     let mint_key: Pubkey = get_mint_from_account(acct)?;
     if &mint_key != mint.key {
         return Err(TimelockError::MintsShouldMatch.into());

--- a/timelock/program/src/utils.rs
+++ b/timelock/program/src/utils.rs
@@ -201,6 +201,17 @@ pub fn assert_mint_authority(mint: &AccountInfo, mint_authority: &Pubkey) -> Pro
     Ok(())
 }
 
+/// Asserts given mint is owned by the provided token program
+pub fn assert_mint_owner_program(
+    mint: &AccountInfo,
+    owner_token_program: &Pubkey,
+) -> ProgramResult {
+    if mint.owner != owner_token_program {
+        return Err(TimelockError::InvalidMintOwnerProgramError.into());
+    }
+    Ok(())
+}
+
 /// assert rent exempt
 pub fn assert_rent_exempt(rent: &Rent, account_info: &AccountInfo) -> ProgramResult {
     if !rent.is_exempt(account_info.lamports(), account_info.data_len()) {
@@ -209,7 +220,7 @@ pub fn assert_rent_exempt(rent: &Rent, account_info: &AccountInfo) -> ProgramRes
         Ok(())
     }
 }
-/// assert ununitialized account
+/// assert uninitialized account
 pub fn assert_uninitialized<T: Pack + IsInitialized>(
     account_info: &AccountInfo,
 ) -> Result<T, ProgramError> {

--- a/timelock/program/src/utils.rs
+++ b/timelock/program/src/utils.rs
@@ -164,7 +164,6 @@ pub fn assert_account_equiv(acct: &AccountInfo, key: &Pubkey) -> ProgramResult {
 }
 
 /// Cheaper Assertion the account has a matching mint - if you dont plan to use Mint for anything else
-#[inline(always)]
 pub fn assert_mint_matching(acct: &AccountInfo, mint: &AccountInfo) -> ProgramResult {
     let mint_key: Pubkey = get_mint_from_account(acct)?;
     if &mint_key != mint.key {
@@ -175,7 +174,6 @@ pub fn assert_mint_matching(acct: &AccountInfo, mint: &AccountInfo) -> ProgramRe
 }
 
 /// Cheaper Assertion the account has a matching mint decimals - if you don't plan to use Mint for anything else
-#[inline(always)]
 pub fn assert_mint_decimals(mint: &AccountInfo, mint_decimals: u8) -> ProgramResult {
     if pull_mint_decimals(mint).unwrap() != mint_decimals {
         return Err(TimelockError::MintsDecimalsShouldMatch.into());
@@ -205,7 +203,6 @@ pub fn assert_uninitialized<T: Pack + IsInitialized>(
 }
 
 /// cheap assertion of mint serialization
-#[inline(always)]
 pub fn assert_cheap_mint_initialized(account_info: &AccountInfo) -> Result<(), ProgramError> {
     // In token program, 36, 8, 1, 1 is the layout, where the last 1 is initialized bit.
     // Not my favorite hack, but necessary to avoid stack size limitations caused by serializing entire Mint
@@ -218,7 +215,6 @@ pub fn assert_cheap_mint_initialized(account_info: &AccountInfo) -> Result<(), P
 }
 
 /// cheap method to just pull supply off a mint
-#[inline(always)]
 pub fn pull_mint_supply(account_info: &AccountInfo) -> Result<u64, ProgramError> {
     // In token program, 36, 8, 1, 1 is the layout, where the first 8 is supply u64.
     // so we start at 36.
@@ -229,7 +225,6 @@ pub fn pull_mint_supply(account_info: &AccountInfo) -> Result<u64, ProgramError>
 }
 
 /// cheap method to just pull decimals off a mint
-#[inline(always)]
 pub fn pull_mint_decimals(account_info: &AccountInfo) -> Result<u8, ProgramError> {
     // In token program, 36, 8, 1, 1 is the Mint layout, where the first 1 is decimals u8.
     // so we start at 44.
@@ -240,7 +235,6 @@ pub fn pull_mint_decimals(account_info: &AccountInfo) -> Result<u8, ProgramError
 }
 
 /// Cheap method to just grab mint Pubkey off token account, instead of deserializing entire thing
-#[inline(always)]
 pub fn get_mint_from_account(account_info: &AccountInfo) -> Result<Pubkey, ProgramError> {
     // Accounts have mint in first 32 bits.
     let data = account_info.try_borrow_data().unwrap();


### PR DESCRIPTION
The following issues have been addressed in the PR:

1. Check the decimals match between voting mints and source mints in initialize
2. In timelock set initialization assert that all the mints provided have authority set to the program (we set it this way int he front end but we want to guarantee it in the backend)
3. In timelock set initialization assert the two dump accounts, the source holding accounts, and the three validation accounts all have as authorities on them the proper authority (I believe it is the program itself), check the front end to be sure. We want to make sure someone doesn’t pass up an account that has a different authority on it so they can mess with us.
4. In timelock set initialization assert mints provided are mints OWNED by token program
5. All Clippy warnings breaking the build
 

